### PR TITLE
Refactored Binding by extracting BindingResolver to improve code structure and simplify the Binding class.

### DIFF
--- a/benchmark_cherrypick/README.md
+++ b/benchmark_cherrypick/README.md
@@ -17,12 +17,12 @@ All scenarios use the public API capabilities of cherrypick (scope, module, bind
 
 | Scenario                                           | RunTime (μs)  |
 |----------------------------------------------------|---------------|
-| RegisterAndResolve                                 | 0.3407        |
-| ChainSingleton (A->B->C, singleton)                | 0.3777        |
-| ChainFactory (A->B->C, factory)                    | 0.9688        |
-| NamedResolve (by name)                             | 0.3878        |
-| AsyncChain (A->B->C, async)                        | 1.8006        |
-| ScopeOverride (child overrides parent)             | 0.3477        |
+| RegisterAndResolve                                 | 0.4574        |
+| ChainSingleton (A->B->C, singleton)                | 0.3759        |
+| ChainFactory (A->B->C, factory)                    | 1.3783        |
+| NamedResolve (by name)                             | 0.5193        |
+| AsyncChain (A->B->C, async)                        | 0.5985        |
+| ScopeOverride (child overrides parent)             | 0.3611        |
 
 ## How to run
 

--- a/benchmark_cherrypick/README.ru.md
+++ b/benchmark_cherrypick/README.ru.md
@@ -17,12 +17,12 @@
 
 | Сценарий                                           | RunTime (мкс) |
 |----------------------------------------------------|--------------|
-| RegisterAndResolve                                 | 0.3407        |
-| ChainSingleton (A->B->C, singleton)                | 0.3777        |
-| ChainFactory (A->B->C, factory)                    | 0.9688        |
-| NamedResolve (by name)                             | 0.3878        |
-| AsyncChain (A->B->C, async)                        | 1.8006        |
-| ScopeOverride (child overrides parent)             | 0.3477        |
+| RegisterAndResolve                                 | 0.4574        |
+| ChainSingleton (A->B->C, singleton)                | 0.3759        |
+| ChainFactory (A->B->C, factory)                    | 1.3783        |
+| NamedResolve (by name)                             | 0.5193        |
+| AsyncChain (A->B->C, async)                        | 0.5985        |
+| ScopeOverride (child overrides parent)             | 0.3611        |
 
 ## Как запускать
 

--- a/cherrypick/example/bin/main.dart
+++ b/cherrypick/example/bin/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:cherrypick/cherrypick.dart';
+import 'package:meta/meta.dart';
 
 class AppModule extends Module {
   @override
@@ -17,19 +18,28 @@ class FeatureModule extends Module {
   @override
   void builder(Scope currentScope) {
     // Using toProvideAsync for async initialization
-    bind<DataRepository>().withName("networkRepo").toProvideAsync(() async {
+    bind<DataRepository>()
+        .withName("networkRepo")
+        .toProvideWithParams((params) async {
+      print('REPO PARAMS: $params');
+
       final client = await Future.delayed(
-          Duration(milliseconds: 100),
-          () => currentScope.resolve<ApiClient>(
-              named: isMock ? "apiClientMock" : "apiClientImpl"));
+        Duration(milliseconds: 1000),
+        () => currentScope.resolve<ApiClient>(
+          named: isMock ? "apiClientMock" : "apiClientImpl",
+        ),
+      );
+
       return NetworkDataRepository(client);
     }).singleton();
 
     // Asynchronous initialization of DataBloc
-    bind<DataBloc>().toProvideAsync(
+    bind<DataBloc>().toProvide(
       () async {
         final repo = await currentScope.resolveAsync<DataRepository>(
-            named: "networkRepo");
+          named: "networkRepo",
+          params: 'Some params',
+        );
         return DataBloc(repo);
       },
     );
@@ -38,18 +48,19 @@ class FeatureModule extends Module {
 
 Future<void> main() async {
   try {
-    final scope = openRootScope().installModules([
-      AppModule(),
-    ]);
+  final scope = openRootScope().installModules([AppModule()]);
 
     final subScope = scope
         .openSubScope("featureScope")
         .installModules([FeatureModule(isMock: true)]);
 
-    // Asynchronous instance resolution
-    final dataBloc = await subScope.resolveAsync<DataBloc>();
-    dataBloc.data.listen((d) => print('Received data: $d'),
-        onError: (e) => print('Error: $e'), onDone: () => print('DONE'));
+  // Asynchronous instance resolution
+  final dataBloc = await subScope.resolveAsync<DataBloc>();
+  dataBloc.data.listen(
+    (d) => print('Received data: $d'),
+    onError: (e) => print('Error: $e'),
+    onDone: () => print('DONE'),
+  );
 
     await dataBloc.fetchData();
   } catch (e) {

--- a/cherrypick/example/bin/main.dart
+++ b/cherrypick/example/bin/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:cherrypick/cherrypick.dart';
-import 'package:meta/meta.dart';
 
 class AppModule extends Module {
   @override

--- a/cherrypick/lib/cherrypick.dart
+++ b/cherrypick/lib/cherrypick.dart
@@ -13,6 +13,7 @@ library;
 // limitations under the License.
 //
 
+export 'package:cherrypick/src/binding_resolver.dart';
 export 'package:cherrypick/src/binding.dart';
 export 'package:cherrypick/src/cycle_detector.dart';
 export 'package:cherrypick/src/global_cycle_detector.dart';

--- a/cherrypick/lib/src/binding.dart
+++ b/cherrypick/lib/src/binding.dart
@@ -11,44 +11,20 @@
 // limitations under the License.
 //
 
-enum Mode { simple, instance, providerInstance, providerInstanceWithParams }
-
-typedef Provider<T> = T? Function();
-
-typedef ProviderWithParams<T> = T Function(dynamic params);
-
-typedef AsyncProvider<T> = Future<T> Function();
-
-typedef AsyncProviderWithParams<T> = Future<T> Function(dynamic params);
+import 'package:cherrypick/src/binding_resolver.dart';
 
 /// RU: Класс Binding<T> настраивает параметры экземпляра.
 /// ENG: The Binding<T> class configures the settings for the instance.
 ///
 class Binding<T> {
-  late Mode _mode;
   late Type _key;
-  late String _name;
-  T? _instance;
-  Future<T>? _instanceAsync;
-  Provider<T>? _provider;
-  ProviderWithParams<T>? _providerWithParams;
+  String? _name;
 
-  AsyncProvider<T>? asyncProvider;
-  AsyncProviderWithParams<T>? asyncProviderWithParams;
-
-  late bool _isSingleton = false;
-  late bool _isNamed = false;
+  BindingResolver<T>? _resolver;
 
   Binding() {
-    _mode = Mode.simple;
     _key = T;
   }
-
-  /// RU: Метод возвращает [Mode] экземпляра.
-  /// ENG: The method returns the [Mode] of the instance.
-  ///
-  /// return [Mode]
-  Mode get mode => _mode;
 
   /// RU: Метод возвращает тип экземпляра.
   /// ENG: The method returns the type of the instance.
@@ -60,19 +36,21 @@ class Binding<T> {
   /// ENG: The method returns the name of the instance.
   ///
   /// return [String]
-  String get name => _name;
-
-  /// RU: Метод проверяет сингелтон экземпляр или нет.
-  /// ENG: The method checks the singleton instance or not.
-  ///
-  /// return [bool]
-  bool get isSingleton => _isSingleton;
+  String? get name => _name;
 
   /// RU: Метод проверяет именован экземпляр или нет.
   /// ENG: The method checks whether the instance is named or not.
   ///
   /// return [bool]
-  bool get isNamed => _isNamed;
+  bool get isNamed => _name != null;
+
+  /// RU: Метод проверяет сингелтон экземпляр или нет.
+  /// ENG: The method checks the singleton instance or not.
+  ///
+  /// return [bool]
+  bool get isSingleton => _resolver?.isSingleton ?? false;
+
+  BindingResolver<T>? get resolver => _resolver;
 
   /// RU: Добавляет имя для экземляпя [value].
   /// ENG: Added name for instance [value].
@@ -80,7 +58,6 @@ class Binding<T> {
   /// return [Binding]
   Binding<T> withName(String name) {
     _name = name;
-    _isNamed = true;
     return this;
   }
 
@@ -88,21 +65,9 @@ class Binding<T> {
   /// ENG: Initialization instance [value].
   ///
   /// return [Binding]
-  Binding<T> toInstance(T value) {
-    _mode = Mode.instance;
-    _instance = value;
-    _isSingleton = true;
-    return this;
-  }
+  Binding<T> toInstance(Instance<T> value) {
+    _resolver = InstanceResolver<T>(value);
 
-  /// RU: Инициализация экземляпяра [value].
-  /// ENG: Initialization instance [value].
-  ///
-  /// return [Binding]
-  Binding<T> toInstanceAsync(Future<T> value) {
-    _mode = Mode.instance;
-    _instanceAsync = value;
-    _isSingleton = true;
     return this;
   }
 
@@ -111,18 +76,8 @@ class Binding<T> {
   ///
   /// return [Binding]
   Binding<T> toProvide(Provider<T> value) {
-    _mode = Mode.providerInstance;
-    _provider = value;
-    return this;
-  }
+    _resolver = ProviderResolver<T>((_) => value.call(), withParams: false);
 
-  /// RU: Инициализация экземляпяра  через провайдер [value].
-  /// ENG: Initialization instance via provider [value].
-  ///
-  /// return [Binding]
-  Binding<T> toProvideAsync(AsyncProvider<T> provider) {
-    _mode = Mode.providerInstance;
-    asyncProvider = provider;
     return this;
   }
 
@@ -131,18 +86,8 @@ class Binding<T> {
   ///
   /// return [Binding]
   Binding<T> toProvideWithParams(ProviderWithParams<T> value) {
-    _mode = Mode.providerInstanceWithParams;
-    _providerWithParams = value;
-    return this;
-  }
+    _resolver = ProviderResolver<T>(value, withParams: true);
 
-  /// RU: Инициализация экземляра через асинхронный провайдер [value] с динамическим параметром.
-  /// ENG: Initializes the instance via async provider [value] with a dynamic param.
-  ///
-  /// return [Binding]
-  Binding<T> toProvideAsyncWithParams(AsyncProviderWithParams<T> provider) {
-    _mode = Mode.providerInstanceWithParams;
-    asyncProviderWithParams = provider;
     return this;
   }
 
@@ -151,40 +96,16 @@ class Binding<T> {
   ///
   /// return [Binding]
   Binding<T> singleton() {
-    _isSingleton = true;
+    _resolver?.toSingleton();
+
     return this;
   }
 
-  /// RU: Поиск экземпляра.
-  /// ENG: Resolve instance.
-  ///
-  /// return [T]
-  T? get instance => _instance;
-
-  /// RU: Поиск экземпляра.
-  /// ENG: Resolve instance.
-  ///
-  /// return [T]
-  Future<T>? get instanceAsync => _instanceAsync;
-
-  /// RU: Поиск экземпляра.
-  /// ENG: Resolve instance.
-  ///
-  /// return [T]
-  T? get provider {
-    if (_isSingleton) {
-      _instance ??= _provider?.call();
-      return _instance;
-    }
-    return _provider?.call();
+  T? resolveSync([dynamic params]) {
+    return resolver?.resolveSync(params);
   }
 
-  /// RU: Поиск экземпляра с параметром.
-  ///
-  /// ENG: Resolve instance with [params].
-  ///
-  /// return [T]
-  T? providerWithParams(dynamic params) {
-    return _providerWithParams?.call(params);
+  Future<T>? resolveAsync([dynamic params]) {
+    return resolver?.resolveAsync(params);
   }
 }

--- a/cherrypick/lib/src/binding.dart
+++ b/cherrypick/lib/src/binding.dart
@@ -91,6 +91,21 @@ class Binding<T> {
     return this;
   }
 
+  @Deprecated('Use toInstance instead of toInstanceAsync')
+  Binding<T> toInstanceAsync(Instance<T> value) {
+    return this.toInstance(value);
+  }
+
+  @Deprecated('Use toProvide instead of toProvideAsync')
+  Binding<T> toProvideAsync(Provider<T> value) {
+    return this.toProvide(value);
+  }
+
+  @Deprecated('Use toProvideWithParams instead of toProvideAsyncWithParams')
+  Binding<T> toProvideAsyncWithParams(ProviderWithParams<T> value) {
+    return this.toProvideWithParams(value);
+  }
+
   /// RU: Инициализация экземляпяра  как сингелтон [value].
   /// ENG: Initialization instance as a singelton [value].
   ///

--- a/cherrypick/lib/src/binding_resolver.dart
+++ b/cherrypick/lib/src/binding_resolver.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+typedef Instance<T> = FutureOr<T>;
+
+/// RU: Синхронный или асинхронный провайдер без параметров, возвращающий [T] или [Future<T>].
+/// ENG: Synchronous or asynchronous provider without parameters, returning [T] or [Future<T>].
+typedef Provider<T> = FutureOr<T> Function();
+
+/// RU: Провайдер с динамическим параметром, возвращающий [T] или [Future<T>] в зависимости от реализации.
+/// ENG: Provider with dynamic parameter, returning [T] or [Future<T>] depending on implementation.
+typedef ProviderWithParams<T> = FutureOr<T> Function(dynamic);
+
+/// RU: Абстрактный интерфейс для классов, которые разрешают зависимости типа [T].
+/// ENG: Abstract interface for classes that resolve dependencies of type [T].
+abstract class BindingResolver<T> {
+  /// RU: Синхронное разрешение зависимости с параметром [params].
+  /// ENG: Synchronous resolution of the dependency with [params].
+  T? resolveSync([dynamic params]);
+
+  /// RU: Асинхронное разрешение зависимости с параметром [params].
+  /// ENG: Asynchronous resolution of the dependency with [params].
+  Future<T>? resolveAsync([dynamic params]);
+
+  /// RU: Помечает текущий резолвер как синглтон — результат будет закеширован.
+  /// ENG: Marks this resolver as singleton — result will be cached.
+  void toSingleton();
+
+  bool get isSingleton;
+}
+
+/// RU: Резолвер, оборачивающий конкретный экземпляр [T] (или Future<T>), без вызова провайдера.
+/// ENG: Resolver that wraps a concrete instance of [T] (or Future<T>), without provider invocation.
+class InstanceResolver<T> implements BindingResolver<T> {
+  final Instance<T> _instance;
+
+  /// RU: Создаёт резолвер, оборачивающий значение [instance].
+  /// ENG: Creates a resolver that wraps the given [instance].
+  InstanceResolver(this._instance);
+
+  @override
+  T resolveSync([_]) {
+    if (_instance is T) return _instance as T;
+    throw StateError(
+      'Instance $_instance is Future; '
+      'use resolveAsync() instead',
+    );
+  }
+
+  @override
+  Future<T> resolveAsync([_]) {
+    if (_instance is Future<T>) return _instance as Future<T>;
+    if (_instance is T) return Future.value(_instance as T);
+    throw StateError('Unexpected instance type: $_instance');
+  }
+
+  @override
+  void toSingleton() {}
+
+  @override
+  bool get isSingleton => true;
+}
+
+/// RU: Резолвер, оборачивающий провайдер, с возможностью синглтон-кеширования.
+/// ENG: Resolver that wraps a provider, with optional singleton caching.
+class ProviderResolver<T> implements BindingResolver<T> {
+  final ProviderWithParams<T> _provider;
+  final bool _withParams;
+
+  FutureOr<T>? _cache;
+  bool _singleton = false;
+
+  /// RU: Создаёт резолвер из произвольной функции [raw], поддерживающей ноль или один параметр.
+  /// ENG: Creates a resolver from arbitrary function [raw], supporting zero or one parameter.
+  ProviderResolver(
+    ProviderWithParams<T> provider, {
+    required bool withParams,
+  })  : _provider = provider,
+        _withParams = withParams;
+
+  @override
+  T resolveSync([dynamic params]) {
+    _checkParams(params);
+
+    final result = _cache ?? _provider(params);
+
+    if (result is T) {
+      if (_singleton) {
+        _cache ??= result;
+      }
+      return result;
+    }
+
+    throw StateError(
+      'Provider [$_provider] return Future<$T>. Use resolveAsync() instead.',
+    );
+  }
+
+  @override
+  Future<T> resolveAsync([dynamic params]) {
+    _checkParams(params);
+
+    final result = _cache ?? _provider(params);
+    final target = result is Future<T> ? result : Future<T>.value(result);
+
+    if (_singleton) {
+      _cache ??= target;
+    }
+
+    return target;
+  }
+
+  @override
+  void toSingleton() {
+    _singleton = true;
+  }
+
+  @override
+  bool get isSingleton => _singleton;
+
+  /// RU: Проверяет, был ли передан параметр, если провайдер требует его.
+  /// ENG: Checks if parameter is passed when the provider expects it.
+  void _checkParams(dynamic params) {
+    if (_withParams && params == null) {
+      throw StateError(
+        '[$T] Params is null. Maybe you forgot to pass it?',
+      );
+    }
+  }
+}

--- a/cherrypick/lib/src/binding_resolver.dart
+++ b/cherrypick/lib/src/binding_resolver.dart
@@ -39,7 +39,7 @@ class InstanceResolver<T> implements BindingResolver<T> {
 
   @override
   T resolveSync([_]) {
-    if (_instance is T) return _instance as T;
+    if (_instance is T) return _instance;
     throw StateError(
       'Instance $_instance is Future; '
       'use resolveAsync() instead',
@@ -48,9 +48,9 @@ class InstanceResolver<T> implements BindingResolver<T> {
 
   @override
   Future<T> resolveAsync([_]) {
-    if (_instance is Future<T>) return _instance as Future<T>;
-    if (_instance is T) return Future.value(_instance as T);
-    throw StateError('Unexpected instance type: $_instance');
+    if (_instance is Future<T>) return _instance;
+
+    return Future.value(_instance);
   }
 
   @override

--- a/cherrypick/test/src/scope_test.dart
+++ b/cherrypick/test/src/scope_test.dart
@@ -127,7 +127,7 @@ void main() {
       final scope = Scope(null)
         ..installModules([
           _InlineModule((m, s) {
-            m.bind<String>().toInstanceAsync(Future.value('async value'));
+            m.bind<String>().toInstance(Future.value('async value'));
           }),
         ]);
       expect(await scope.resolveAsync<String>(), "async value");
@@ -137,7 +137,7 @@ void main() {
       final scope = Scope(null)
         ..installModules([
           _InlineModule((m, s) {
-            m.bind<int>().toProvideAsync(() async => 7);
+            m.bind<int>().toProvide(() async => 7);
           }),
         ]);
       expect(await scope.resolveAsync<int>(), 7);
@@ -147,7 +147,7 @@ void main() {
       final scope = Scope(null)
         ..installModules([
           _InlineModule((m, s) {
-            m.bind<int>().toProvideAsyncWithParams((x) async => (x as int) * 3);
+            m.bind<int>().toProvideWithParams((x) async => (x as int) * 3);
           }),
         ]);
       expect(await scope.resolveAsync<int>(params: 2), 6);


### PR DESCRIPTION
Extracted dependency resolution logic into a separate BindingResolver class:

- Introduced a hierarchy of resolvers (InstanceResolver, ProviderResolver, etc.) to encapsulate dependency creation and management.
- Simplified the Binding class by moving resolution logic into dedicated classes.