### PR TITLE
feat: migrate to analyzer 9.0.0 API

### DIFF
--- a/cherrypick_generator/lib/inject_generator.dart
+++ b/cherrypick_generator/lib/inject_generator.dart
@@ -12,7 +12,7 @@
 //
 
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
@@ -100,11 +100,11 @@ class InjectGenerator extends GeneratorForAnnotation<ann.injectable> {
   /// ```
   @override
   dynamic generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) {
-    if (element is! ClassElement2) {
+    if (element is! ClassElement) {
       throw InvalidGenerationSourceError(
         '@injectable() can only be applied to classes.',
         element: element,
@@ -112,7 +112,7 @@ class InjectGenerator extends GeneratorForAnnotation<ann.injectable> {
     }
 
     final classElement = element;
-    final className = classElement.firstFragment.name2;
+    final className = classElement.name;
     final mixinName = '_\$$className';
 
     final buffer = StringBuffer()
@@ -120,7 +120,7 @@ class InjectGenerator extends GeneratorForAnnotation<ann.injectable> {
       ..writeln('  void _inject($className instance) {');
 
     // Collect and process all @inject fields
-    final injectFields = classElement.fields2
+    final injectFields = classElement.fields
         .where((f) => _isInjectField(f))
         .map((f) => _parseInjectField(f));
 
@@ -138,8 +138,8 @@ class InjectGenerator extends GeneratorForAnnotation<ann.injectable> {
   /// Returns true if a field is annotated with `@inject`.
   ///
   /// Used to detect which fields should be processed for injection.
-  static bool _isInjectField(FieldElement2 field) {
-    return field.firstFragment.metadata2.annotations.any(
+  static bool _isInjectField(FieldElement field) {
+    return field.metadata.annotations.any(
       (m) => m.computeConstantValue()?.type?.getDisplayString() == 'inject',
     );
   }
@@ -149,11 +149,11 @@ class InjectGenerator extends GeneratorForAnnotation<ann.injectable> {
   ///
   /// Converts Dart field declaration and all parameterizing injection-related
   /// annotations into a [_ParsedInjectField] which is used for codegen.
-  static _ParsedInjectField _parseInjectField(FieldElement2 field) {
+  static _ParsedInjectField _parseInjectField(FieldElement field) {
     String? scopeName;
     String? namedValue;
 
-    for (final meta in field.firstFragment.metadata2.annotations) {
+    for (final meta in field.metadata.annotations) {
       final DartObject? obj = meta.computeConstantValue();
       final type = obj?.type?.getDisplayString();
       if (type == 'scope') {
@@ -185,7 +185,7 @@ class InjectGenerator extends GeneratorForAnnotation<ann.injectable> {
             ));
 
     return _ParsedInjectField(
-      fieldName: field.firstFragment.name2 ?? '',
+      fieldName: field.name!,
       coreType: coreTypeName.replaceAll('?', ''), // удаляем "?" на всякий
       isFuture: isFuture,
       isNullable: isNullable,

--- a/cherrypick_generator/lib/module_generator.dart
+++ b/cherrypick_generator/lib/module_generator.dart
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:cherrypick_annotations/cherrypick_annotations.dart' as ann;
@@ -80,11 +80,11 @@ class ModuleGenerator extends GeneratorForAnnotation<ann.module> {
   /// See file-level docs for usage and generated output example.
   @override
   dynamic generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) {
-    if (element is! ClassElement2) {
+    if (element is! ClassElement) {
       throw InvalidGenerationSourceError(
         '@module() can only be applied to classes.',
         element: element,

--- a/cherrypick_generator/lib/src/bind_spec.dart
+++ b/cherrypick_generator/lib/src/bind_spec.dart
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 
 import 'bind_parameters_spec.dart';
 import 'metadata_utils.dart';
@@ -251,7 +251,7 @@ class BindSpec {
   /// print(bindSpec.returnType); // e.g., 'Logger'
   /// ```
   /// Throws [AnnotationValidationException] or [CodeGenerationException] if invalid.
-  static BindSpec fromMethod(MethodElement2 method) {
+  static BindSpec fromMethod(MethodElement method) {
     try {
       // Validate method annotations
       AnnotationValidator.validateMethodAnnotations(method);
@@ -259,17 +259,17 @@ class BindSpec {
       // Parse return type using improved type parser
       final parsedReturnType = TypeParser.parseType(method.returnType, method);
 
-      final methodName = method.firstFragment.name2 ?? '';
+      final methodName = method.name ?? '';
 
       // Check for @singleton annotation.
       final isSingleton = MetadataUtils.anyMeta(
-        method.firstFragment.metadata2.annotations,
+        method.metadata.annotations,
         'singleton',
       );
 
       // Get @named value if present.
       final named = MetadataUtils.getNamedValue(
-        method.firstFragment.metadata2.annotations,
+        method.metadata.annotations,
       );
 
       // Parse each method parameter.
@@ -278,10 +278,10 @@ class BindSpec {
       for (final p in method.formalParameters) {
         final typeStr = p.type.getDisplayString();
         final paramNamed = MetadataUtils.getNamedValue(
-          p.firstFragment.metadata2.annotations,
+          p.metadata.annotations,
         );
         final isParams = MetadataUtils.anyMeta(
-          p.firstFragment.metadata2.annotations,
+          p.metadata.annotations,
           'params',
         );
         if (isParams) hasParams = true;
@@ -290,11 +290,11 @@ class BindSpec {
 
       // Determine bindingType: @instance or @provide.
       final hasInstance = MetadataUtils.anyMeta(
-        method.firstFragment.metadata2.annotations,
+        method.metadata.annotations,
         'instance',
       );
       final hasProvide = MetadataUtils.anyMeta(
-        method.firstFragment.metadata2.annotations,
+        method.metadata.annotations,
         'provide',
       );
 

--- a/cherrypick_generator/lib/src/exceptions.dart
+++ b/cherrypick_generator/lib/src/exceptions.dart
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// ---------------------------------------------------------------------------
@@ -48,7 +48,7 @@ class CherryPickGeneratorException extends InvalidGenerationSourceError {
 
   CherryPickGeneratorException(
     String message, {
-    required Element2 element,
+    required Element element,
     required this.category,
     this.suggestion,
     this.context,
@@ -62,7 +62,7 @@ class CherryPickGeneratorException extends InvalidGenerationSourceError {
     String category,
     String? suggestion,
     Map<String, dynamic>? context,
-    Element2 element,
+    Element element,
   ) {
     final buffer = StringBuffer();
 

--- a/cherrypick_generator/lib/src/generated_class.dart
+++ b/cherrypick_generator/lib/src/generated_class.dart
@@ -12,7 +12,6 @@
 //
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/element2.dart';
 import 'bind_spec.dart';
 
 /// ---------------------------------------------------------------------------
@@ -76,11 +75,11 @@ class GeneratedClass {
   /// final gen = GeneratedClass.fromClassElement(classElement);
   /// print(gen.generatedClassName); // e.g. $AppModule
   /// ```
-  static GeneratedClass fromClassElement(ClassElement2 element) {
-    final className = element.firstFragment.name2 ?? '';
+  static GeneratedClass fromClassElement(ClassElement element) {
+    final className = element.name ?? '';
     final generatedClassName = r'$' + className;
     final sourceFile = element.firstFragment.libraryFragment.source.shortName;
-    final binds = element.methods2
+    final binds = element.methods
         .where((m) => !m.isAbstract)
         .map(BindSpec.fromMethod)
         .toList();

--- a/cherrypick_generator/lib/src/metadata_utils.dart
+++ b/cherrypick_generator/lib/src/metadata_utils.dart
@@ -23,10 +23,10 @@ import 'package:analyzer/dart/element/element.dart';
 ///
 /// # Example usage
 /// ```dart
-/// if (MetadataUtils.anyMeta(method.metadata, 'singleton')) {
+/// if (MetadataUtils.anyMeta(method.metadata.annotations, 'singleton')) {
 ///   // The method is annotated with @singleton
 /// }
-/// final name = MetadataUtils.getNamedValue(field.metadata);
+/// final name = MetadataUtils.getNamedValue(field.metadata.annotations);
 /// if (name != null) print('@named value: $name');
 /// ```
 /// ---------------------------------------------------------------------------
@@ -38,7 +38,7 @@ class MetadataUtils {
   ///
   /// Example:
   /// ```dart
-  /// bool isSingleton = MetadataUtils.anyMeta(myMethod.metadata, 'singleton');
+  /// bool isSingleton = MetadataUtils.anyMeta(myMethod.metadata.annotations, 'singleton');
   /// ```
   static bool anyMeta(List<ElementAnnotation> meta, String typeName) {
     return meta.any(

--- a/cherrypick_generator/lib/src/type_parser.dart
+++ b/cherrypick_generator/lib/src/type_parser.dart
@@ -11,7 +11,7 @@
 // limitations under the License.
 //
 
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'exceptions.dart';
@@ -45,7 +45,7 @@ class TypeParser {
   /// final parsed = TypeParser.parseType(field.type, field);
   /// if (parsed.isNullable) print('Field is nullable');
   /// ```
-  static ParsedType parseType(DartType dartType, Element2 context) {
+  static ParsedType parseType(DartType dartType, Element context) {
     try {
       return _parseTypeInternal(dartType, context);
     } catch (e) {
@@ -61,7 +61,7 @@ class TypeParser {
     }
   }
 
-  static ParsedType _parseTypeInternal(DartType dartType, Element2 context) {
+  static ParsedType _parseTypeInternal(DartType dartType, Element context) {
     final displayString = dartType.getDisplayString();
     final isNullable = dartType.nullabilitySuffix == NullabilitySuffix.question;
 
@@ -88,7 +88,7 @@ class TypeParser {
 
   static ParsedType _parseFutureType(
     DartType dartType,
-    Element2 context,
+    Element context,
     bool isNullable,
   ) {
     if (dartType is! ParameterizedType || dartType.typeArguments.isEmpty) {
@@ -116,7 +116,7 @@ class TypeParser {
 
   static ParsedType _parseGenericType(
     ParameterizedType dartType,
-    Element2 context,
+    Element context,
     bool isNullable,
   ) {
     final typeArguments = dartType.typeArguments
@@ -144,7 +144,7 @@ class TypeParser {
   /// final parsed = TypeParser.parseType(field.type, field);
   /// TypeParser.validateInjectableType(parsed, field);
   /// ```
-  static void validateInjectableType(ParsedType parsedType, Element2 context) {
+  static void validateInjectableType(ParsedType parsedType, Element context) {
     // Check for void type
     if (parsedType.coreType == 'void') {
       throw TypeParsingException(

--- a/cherrypick_generator/pubspec.yaml
+++ b/cherrypick_generator/pubspec.yaml
@@ -20,9 +20,9 @@ environment:
 # Add regular dependencies here.
 dependencies:
   cherrypick_annotations: ^4.0.0-dev.0
-  analyzer: ">=8.2.9 <10.0.1"
+  analyzer: ^9.0.0
   dart_style: ^3.0.0
-  build: ^3.0.0
+  build: ^4.0.4
   source_gen: ^4.2.0
   collection: ^1.18.0
 

--- a/cherrypick_generator/test/type_parser_test.dart
+++ b/cherrypick_generator/test/type_parser_test.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:test/test.dart';
 
 import 'package:cherrypick_generator/src/type_parser.dart';
@@ -223,19 +223,13 @@ void main() {
 }
 
 // Mock element for testing
-Element2 _createMockElement() {
+Element _createMockElement() {
   return _MockElement();
 }
 
-class _MockElement implements Element2 {
+class _MockElement implements Element {
   @override
   String get displayName => 'MockElement';
-
-  //@override
-  //String get name => 'MockElement';
-  //
-  //@override
-  //Source? get source => null;
 
   @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/examples/client_app/pubspec.lock
+++ b/examples/client_app/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "9.0.0"
   args:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
+      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.4"
   build_config:
     dependency: transitive
     description:
@@ -65,30 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
+      sha256: b4d854962a32fd9f8efc0b76f98214790b833af8b2e9b2df6bfc927c0415a072
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.1"
+    version: "2.10.5"
   built_collection:
     dependency: transitive
     description:
@@ -134,7 +118,7 @@ packages:
       path: "../../cherrypick_annotations"
       relative: true
     source: path
-    version: "3.0.2"
+    version: "4.0.0-dev.0"
   cherrypick_flutter:
     dependency: "direct main"
     description:
@@ -148,7 +132,7 @@ packages:
       path: "../../cherrypick_generator"
       relative: true
     source: path
-    version: "3.0.2"
+    version: "4.0.0-dev.0"
   clock:
     dependency: transitive
     description:
@@ -247,14 +231,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  frontend_server_client:
-    dependency: transitive
-    description:
-      name: frontend_server_client
-      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -500,14 +476,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/examples/postly/pubspec.lock
+++ b/examples/postly/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "9.0.0"
   ansi_styles:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
+      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.4"
   build_config:
     dependency: transitive
     description:
@@ -105,30 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
+      sha256: b4d854962a32fd9f8efc0b76f98214790b833af8b2e9b2df6bfc927c0415a072
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.1"
+    version: "2.10.5"
   built_collection:
     dependency: transitive
     description:
@@ -182,14 +166,14 @@ packages:
       path: "../../cherrypick_annotations"
       relative: true
     source: path
-    version: "3.0.2"
+    version: "4.0.0-dev.0"
   cherrypick_generator:
     dependency: "direct dev"
     description:
       path: "../../cherrypick_generator"
       relative: true
     source: path
-    version: "3.0.2"
+    version: "4.0.0-dev.0"
   cli_launcher:
     dependency: transitive
     description:
@@ -369,10 +353,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      sha256: "03dd9b7423ff0e31b7e01b2204593e5e1ac5ee553b6ea9d8184dff4a26b9fb07"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.4"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -465,10 +449,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      sha256: "5b89c1e32ae3840bb20a1b3434e3a590173ad3cb605896fb0f60487ce2f8104e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.2"
+    version: "6.11.4"
   leak_tracker:
     dependency: transitive
     description:
@@ -782,10 +766,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4a85e90b50694e652075cbe4575665539d253e6ec10e46e76b45368ab5e3caae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.10"
   source_span:
     dependency: transitive
     description:
@@ -889,14 +873,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/examples/postly/pubspec.yaml
+++ b/examples/postly/pubspec.yaml
@@ -41,7 +41,7 @@ dev_dependencies:
   cherrypick_generator: ^4.0.0-dev.0
   
   json_serializable: ^6.9.0
-  retrofit_generator: ^10.0.5
+  retrofit_generator: ^10.2.1
   auto_route_generator: ^10.0.1
   freezed: ^3.0.0
   melos: ^6.3.2


### PR DESCRIPTION
- Replace Element2 API with Element API
- Update imports from element2.dart to element.dart
- Replace .firstFragment.name2 with .name
- Replace .firstFragment.metadata2.annotations with .metadata.annotations
- Replace .fields2 with .fields
- Replace .methods2 with .methods
- Remove duplicate imports in annotation_validator.dart and generated_class.dart
- Update test mocks to use Element instead of Element2

All generators now work correctly with analyzer 9.0.0:
- melos analyze: SUCCESS (0 issues)
- melos codegen: SUCCESS (13 outputs generated)
- melos bootstrap: SUCCESS (8 packages)